### PR TITLE
Apply suggestions

### DIFF
--- a/__tests__/domain/entities/shared/Entity.test.ts
+++ b/__tests__/domain/entities/shared/Entity.test.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityData } from '../../../../domain/entities/shared/Entity';
+import { Entity } from '../../../../domain/entities/shared/Entity';
 
 class SampleEntity extends Entity<any> {
   constructor(id: string) {
@@ -28,13 +28,6 @@ describe('Entity Class tests', () => {
     const entity2 = new SampleEntity('456');
 
     expect(entity1.equals(entity2)).toBe(false);
-  });
-
-  it('equals method should return false for non-entity objects', () => {
-    const entity1 = new SampleEntity(entityId);
-    const nonEntityObject: EntityData = { id: entityId };
-
-    expect(entity1.equals(nonEntityObject as any)).toBe(false);
   });
 
   it('equals method should return false for null or undefined', () => {

--- a/__tests__/domain/useCases/CreateUser.test.ts
+++ b/__tests__/domain/useCases/CreateUser.test.ts
@@ -64,7 +64,7 @@ describe('AddUserUseCase', () => {
   });
 
   it('should throw an error when trying to add an existing user with the same email', async () => {
-    await expect(addUserUseCase.run(mockUser2)).rejects.toThrow('User aleady exists');
+    await expect(addUserUseCase.run(mockUser2)).rejects.toThrow('User already exists');
 
     expect(mockUserRepository.createUser).not.toHaveBeenCalled();
   });

--- a/domain/entities/shared/Entity.ts
+++ b/domain/entities/shared/Entity.ts
@@ -1,8 +1,5 @@
-export interface EntityData {
-  id: string;
-}
 
-export abstract class Entity<T> implements EntityData {
+export abstract class Entity<T> {
   constructor(public id: string) {
     this.id = id;
   }

--- a/domain/repositories/UserRepository.ts
+++ b/domain/repositories/UserRepository.ts
@@ -1,4 +1,6 @@
-export interface UserRepository<User> {
+import { User } from "domain/entities/User";
+
+export interface UserRepository {
   getUsers(): Promise<User[]>;
 
   createUser(user: User): Promise<void>;

--- a/domain/useCases/CreateUser.ts
+++ b/domain/useCases/CreateUser.ts
@@ -16,7 +16,7 @@ export class CreateUserUseCase {
         const userWithSameDomain = users.find(usr => usr.email.value.includes(userDomain));
 
         if(userWithSameEmail) {
-            throw new Error("User aleady exists");
+            throw new Error("User already exists");
         }
 
         if(userWithSameDomain) {

--- a/domain/useCases/CreateUser.ts
+++ b/domain/useCases/CreateUser.ts
@@ -2,9 +2,9 @@ import { User } from "../entities/User";
 import { UserRepository } from "../repositories/UserRepository";
 
 export class CreateUserUseCase {
-    private userRepository: UserRepository<User>;
+    private userRepository: UserRepository;
 
-    constructor(userRepository: UserRepository<User>){
+    constructor(userRepository: UserRepository){
         this.userRepository = userRepository;
     }
 

--- a/domain/useCases/GetUsers.ts
+++ b/domain/useCases/GetUsers.ts
@@ -2,9 +2,9 @@ import { User } from "../entities/User";
 import { UserRepository } from "../repositories/UserRepository";
 
 export class GetUsersUseCase {
-    private userRepository: UserRepository<User>;
+    private userRepository: UserRepository;
 
-    constructor(userRepository: UserRepository<User>){
+    constructor(userRepository: UserRepository){
         this.userRepository = userRepository;
     }
 

--- a/infrastucture/repositories/UserInMemoryRepository.ts
+++ b/infrastucture/repositories/UserInMemoryRepository.ts
@@ -1,7 +1,7 @@
 import { User } from '../../domain/entities/User';
 import { UserRepository } from '../../domain/repositories/UserRepository';
 
-export class UserInMemoryRepository implements UserRepository<User> {
+export class UserInMemoryRepository implements UserRepository {
     users: User[];
 
     constructor(){


### PR DESCRIPTION
se aplican los siguientes cambios en base a los comentarios que nos dieron al presentar la kata:
- `UserRepository`: su nombre ya indica sobre que entidad va a trabajar, en este caso `User`, en lugar de pasarle el genérico, se puede importar el tipo desde la definición de la interfaz.
- `Entity<T>`: he borrado la interfaz `EntityData`, creo que no hace falta, ya que el id lo tenemos definido a nivel de la entidad `User`,  sino cada entidad que creemos tendrá un `id`.

si alguno de estos cambios no va bien, no lo aplicamos

